### PR TITLE
Release v1.2.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.0
+current_version = 1.2.0
 commit = False
 allow_dirty = True
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ ci:
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 21.8b0
+    rev: 21.9b0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort

--- a/README.md
+++ b/README.md
@@ -22,17 +22,16 @@ Add this to your `.pre-commit-config.yaml`
 
 ## Hooks
 ### `matlab-reflow-comments`
-Reflow comments (lines beginning with `%`) in MATLAB file(s) (`*.m`) to the specified line length.
+Reflow inline comments (lines beginning with `%`) or block comments (delimited by `%{` and `%}`) in MATLAB file(s) (`*.m`) to the specified line length.
 
 Blank comment lines are passed back into the reformatted source code.
 
 * Specify line length with `args: [--line-length=100]` (Default: `75`)
 * Ignore comments with inner indentation `args: [--ignore-indented=True]` (Default: `True`)
+* Also reflow block comments `args: [--reflow-block-comments=True]` (Default: `True`)
 * Use `args: [--alternate-capital-handling=True]` to treat comment lines that begin with a capital letter as the start of a new comment block (Default: `False`)
 
-If `ignore-indented` is `True`, comments that contain inner indentation of at least two spaces
-is passed back into the reformatted source code as-is. Leading whitespace in the line is not
-considered.
+If `ignore-indented` is `True`, comments that contain inner indentation of at least two spaces is passed back into the reformatted source code as-is. Leading whitespace in the line is not considered.
 
 For example:
 
@@ -43,8 +42,9 @@ For example:
 %    This is indented
 ```
 
-If `alternate-capital-handling` is `True`, if the line buffer has contents then a line beginning
-with a capital letter is treated as the start of a new comment block.
+**NOTE:** This logic currently does not apply to the contents of a block comment.
+
+If `alternate-capital-handling` is `True`, if the line buffer has contents then a line beginning with a capital letter is treated as the start of a new comment block.
 
 For example:
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add this to your `.pre-commit-config.yaml`
 
 ```yaml
 -   repo: https://github.com/sco1/pre-commit-matlab
-    rev: v1.1.0
+    rev: v1.2.0
     hooks:
     -   id: matlab-reflow-comments
         args: [--line-length=100]
@@ -26,10 +26,12 @@ Reflow inline comments (lines beginning with `%`) or block comments (delimited b
 
 Blank comment lines are passed back into the reformatted source code.
 
-* Specify line length with `args: [--line-length=100]` (Default: `75`)
-* Ignore comments with inner indentation `args: [--ignore-indented=True]` (Default: `True`)
-* Also reflow block comments `args: [--reflow-block-comments=True]` (Default: `True`)
-* Use `args: [--alternate-capital-handling=True]` to treat comment lines that begin with a capital letter as the start of a new comment block (Default: `False`)
+* Use `--line-length` to specify line length. (Default: `75`)
+* Use `--reflow-block-comments` to control block comment reflow. (Default: `True`)
+* Use `--ignore-indented` to ignore comments with inner indentation. (Default: `True`)
+  * **NOTE:** This logic *is not* applied to the contents of a block comment.
+* Use `--alternate-capital-handling` to treat comment lines that begin with a capital letter as the start of a new comment block. (Default: `False`)
+  * **NOTE:** This logic *is not* applied to the contents of a block comment.
 
 If `ignore-indented` is `True`, comments that contain inner indentation of at least two spaces is passed back into the reformatted source code as-is. Leading whitespace in the line is not considered.
 
@@ -41,8 +43,6 @@ For example:
 %  This is indented
 %    This is indented
 ```
-
-**NOTE:** This logic currently does not apply to the contents of a block comment.
 
 If `alternate-capital-handling` is `True`, if the line buffer has contents then a line beginning with a capital letter is treated as the start of a new comment block.
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -37,7 +37,7 @@ testing = ["pytest (>=4.6)", "pytest-flake8", "pytest-cov", "pytest-black (>=0.3
 
 [[package]]
 name = "black"
-version = "21.8b0"
+version = "21.9b0"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false
@@ -163,7 +163,7 @@ typed-ast = {version = ">=1.4,<2.0", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "flake8-bugbear"
-version = "21.4.3"
+version = "21.9.1"
 description = "A plugin for flake8 finding likely bugs and design problems in your program. Contains warnings that don't belong in pyflakes and pycodestyle."
 category = "dev"
 optional = false
@@ -547,7 +547,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "tox"
-version = "3.24.3"
+version = "3.24.4"
 description = "tox is a generic virtualenv management and test command line tool"
 category = "dev"
 optional = false
@@ -586,7 +586,7 @@ python-versions = "*"
 
 [[package]]
 name = "virtualenv"
-version = "20.7.2"
+version = "20.8.0"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -636,8 +636,8 @@ attrs = [
     {file = "backports.entry_points_selectable-1.1.0.tar.gz", hash = "sha256:988468260ec1c196dab6ae1149260e2f5472c9110334e5d51adcb77867361f6a"},
 ]
 black = [
-    {file = "black-21.8b0-py3-none-any.whl", hash = "sha256:2a0f9a8c2b2a60dbcf1ccb058842fb22bdbbcb2f32c6cc02d9578f90b92ce8b7"},
-    {file = "black-21.8b0.tar.gz", hash = "sha256:570608d28aa3af1792b98c4a337dbac6367877b47b12b88ab42095cfc1a627c2"},
+    {file = "black-21.9b0-py3-none-any.whl", hash = "sha256:380f1b5da05e5a1429225676655dddb96f5ae8c75bdf91e53d798871b902a115"},
+    {file = "black-21.9b0.tar.gz", hash = "sha256:7de4cfc7eb6b710de325712d40125689101d21d25283eed7e9998722cf10eb91"},
 ]
 bump2version = [
     {file = "bump2version-1.0.1-py2.py3-none-any.whl", hash = "sha256:37f927ea17cde7ae2d7baf832f8e80ce3777624554a653006c9144f8017fe410"},
@@ -729,8 +729,8 @@ flake8-annotations = [
     {file = "flake8_annotations-2.6.2-py3-none-any.whl", hash = "sha256:d10c4638231f8a50c0a597c4efce42bd7b7d85df4f620a0ddaca526138936a4f"},
 ]
 flake8-bugbear = [
-    {file = "flake8-bugbear-21.4.3.tar.gz", hash = "sha256:2346c81f889955b39e4a368eb7d508de723d9de05716c287dc860a4073dc57e7"},
-    {file = "flake8_bugbear-21.4.3-py36.py37.py38-none-any.whl", hash = "sha256:4f305dca96be62bf732a218fe6f1825472a621d3452c5b994d8f89dae21dbafa"},
+    {file = "flake8-bugbear-21.9.1.tar.gz", hash = "sha256:2f60c8ce0dc53d51da119faab2d67dea978227f0f92ed3c44eb7d65fb2e06a96"},
+    {file = "flake8_bugbear-21.9.1-py36.py37.py38-none-any.whl", hash = "sha256:45bfdccfb9f2d8aa140e33cac8f46f1e38215c13d5aa8650e7e188d84e2f94c6"},
 ]
 flake8-docstrings = [
     {file = "flake8-docstrings-1.6.0.tar.gz", hash = "sha256:9fe7c6a306064af8e62a055c2f61e9eb1da55f84bb39caef2b84ce53708ac34b"},
@@ -943,8 +943,8 @@ tomli = [
     {file = "tomli-1.2.1.tar.gz", hash = "sha256:a5b75cb6f3968abb47af1b40c1819dc519ea82bcc065776a866e8d74c5ca9442"},
 ]
 tox = [
-    {file = "tox-3.24.3-py2.py3-none-any.whl", hash = "sha256:9fbf8e2ab758b2a5e7cb2c72945e4728089934853076f67ef18d7575c8ab6b88"},
-    {file = "tox-3.24.3.tar.gz", hash = "sha256:c6c4e77705ada004283610fd6d9ba4f77bc85d235447f875df9f0ba1bc23b634"},
+    {file = "tox-3.24.4-py2.py3-none-any.whl", hash = "sha256:5e274227a53dc9ef856767c21867377ba395992549f02ce55eb549f9fb9a8d10"},
+    {file = "tox-3.24.4.tar.gz", hash = "sha256:c30b57fa2477f1fb7c36aa1d83292d5c2336cd0018119e1b1c17340e2c2708ca"},
 ]
 typed-ast = [
     {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6"},
@@ -984,8 +984,8 @@ typing-extensions = [
     {file = "typing_extensions-3.10.0.2.tar.gz", hash = "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.7.2-py2.py3-none-any.whl", hash = "sha256:e4670891b3a03eb071748c569a87cceaefbf643c5bac46d996c5a45c34aa0f06"},
-    {file = "virtualenv-20.7.2.tar.gz", hash = "sha256:9ef4e8ee4710826e98ff3075c9a4739e2cb1040de6a2a8d35db0055840dc96a0"},
+    {file = "virtualenv-20.8.0-py2.py3-none-any.whl", hash = "sha256:a4b987ec31c3c9996cf1bc865332f967fe4a0512c41b39652d6224f696e69da5"},
+    {file = "virtualenv-20.8.0.tar.gz", hash = "sha256:4da4ac43888e97de9cf4fdd870f48ed864bbfd133d2c46cbdec941fed4a25aef"},
 ]
 zipp = [
     {file = "zipp-3.5.0-py3-none-any.whl", hash = "sha256:957cfda87797e389580cb8b9e3870841ca991e2125350677b2ca83a0e99390a3"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -232,7 +232,7 @@ importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "identify"
-version = "2.2.14"
+version = "2.2.15"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -653,6 +653,7 @@ click = [
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
+    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 coverage = [
     {file = "coverage-5.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf"},
@@ -753,8 +754,8 @@ flake8-tidy-imports = [
     {file = "flake8_tidy_imports-4.4.1-py3-none-any.whl", hash = "sha256:631a1ba9daaedbe8bb53f6086c5a92b390e98371205259e0e311a378df8c3dc8"},
 ]
 identify = [
-    {file = "identify-2.2.14-py2.py3-none-any.whl", hash = "sha256:113a76a6ba614d2a3dd408b3504446bcfac0370da5995aa6a17fd7c6dffde02d"},
-    {file = "identify-2.2.14.tar.gz", hash = "sha256:32f465f3c48083f345ad29a9df8419a4ce0674bf4a8c3245191d65c83634bdbf"},
+    {file = "identify-2.2.15-py2.py3-none-any.whl", hash = "sha256:de83a84d774921669774a2000bf87ebba46b4d1c04775f4a5d37deff0cf39f73"},
+    {file = "identify-2.2.15.tar.gz", hash = "sha256:528a88021749035d5a39fe2ba67c0642b8341aaf71889da0e1ed669a429b87f0"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-4.8.1-py3-none-any.whl", hash = "sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15"},
@@ -765,6 +766,7 @@ importlib-resources = [
     {file = "importlib_resources-5.2.2.tar.gz", hash = "sha256:a65882a4d0fe5fbf702273456ba2ce74fe44892c25e42e057aca526b702a6d4b"},
 ]
 iniconfig = [
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 isort = [

--- a/pre_commit_matlab/matlab_reflow_comments.py
+++ b/pre_commit_matlab/matlab_reflow_comments.py
@@ -45,7 +45,11 @@ def _write_line(
 
 
 def process_file(
-    file: Path, line_length: int, ignore_indented: bool, alternate_capital_handling: bool
+    file: Path,
+    line_length: int,
+    ignore_indented: bool,
+    alternate_capital_handling: bool,
+    reflow_block_comments: bool,
 ) -> None:
     """
     Reflow comments (`%`) in the provided MATLAB file (`*.m`) to the specified line length.
@@ -124,10 +128,17 @@ def main(argv: t.Optional[t.Sequence[str]] = None) -> None:  # pragma: no cover 
     parser.add_argument("--line-length", type=int, default=78)
     parser.add_argument("--ignore-indented", type=bool, default=True)
     parser.add_argument("--alternate-capital-handling", type=bool, default=False)
+    parser.add_argument("--reflow-block-comments", type=bool, default=True)
     args = parser.parse_args(argv)
 
     for file in args.filenames:
-        process_file(file, args.line_length, args.ignore_indented, args.alternate_capital_handling)
+        process_file(
+            file,
+            args.line_length,
+            args.ignore_indented,
+            args.alternate_capital_handling,
+            args.reflow_block_comments,
+        )
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/pre_commit_matlab/matlab_reflow_comments.py
+++ b/pre_commit_matlab/matlab_reflow_comments.py
@@ -20,8 +20,7 @@ def _dump_buffer(
     The buffer is cleared & returned after the new line(s) are written.
     """
     if is_block:
-        initial = f"{' '*indent_level}"
-        following = f"{' '*indent_level}"
+        initial = following = f"{' '*indent_level}"
     else:
         initial = f"{' '*indent_level}%"  # Don't include the initial leading space
         following = f"{' '*indent_level}% "
@@ -102,6 +101,7 @@ def process_file(
                 continue
 
             # If we're inside a comment block, lines will likely not begin with a %
+            # Since we're dumping lines inside comment blocks as-is, we can short-circuit here
             if reflow_block_comments and in_comment_block:
                 if buffer:
                     # If this isn't the first line in the text block we need to add a leading space

--- a/pre_commit_matlab/matlab_reflow_comments.py
+++ b/pre_commit_matlab/matlab_reflow_comments.py
@@ -9,17 +9,28 @@ def _n_leading_spaces(line: str) -> int:
     return len(line) - len(line.lstrip())
 
 
-def _dump_buffer(f: t.TextIO, buffer: deque, line_length: int, indent_level: int) -> deque:
+def _dump_buffer(
+    f: t.TextIO, buffer: deque, line_length: int, indent_level: int, is_block: bool = False
+) -> deque:
     """
     Reflow the buffered line(s) to the specified line length, preserving the indent level.
 
+    If `is_block` is true, lines will be prefixed by indentation only & not contain a `%` char.
+
     The buffer is cleared & returned after the new line(s) are written.
     """
+    if is_block:
+        initial = f"{' '*indent_level}"
+        following = f"{' '*indent_level}"
+    else:
+        initial = f"{' '*indent_level}%"  # Don't include the initial leading space
+        following = f"{' '*indent_level}% "
+
     reflowed_src = textwrap.fill(
         "".join(buffer),
         width=line_length,
-        initial_indent=f"{' '*indent_level}%",  # Don't include the initial leading space
-        subsequent_indent=f"{' '*indent_level}% ",
+        initial_indent=initial,
+        subsequent_indent=following,
         break_on_hyphens=False,
     )
     reflowed_src = f"{reflowed_src}\n"
@@ -30,7 +41,12 @@ def _dump_buffer(f: t.TextIO, buffer: deque, line_length: int, indent_level: int
 
 
 def _write_line(
-    f: t.TextIO, line: str, buffer: deque, line_length: int, indent_level: int
+    f: t.TextIO,
+    line: str,
+    buffer: deque,
+    line_length: int,
+    indent_level: int,
+    is_block: bool = False,
 ) -> deque:
     """
     Write the provided source line after checking for buffered comments to empty.
@@ -38,7 +54,7 @@ def _write_line(
     The buffer is cleared & returned after the new line(s) are written.
     """
     if buffer:
-        buffer = _dump_buffer(f, buffer, line_length, indent_level)
+        buffer = _dump_buffer(f, buffer, line_length, indent_level, is_block)
     f.write(f"{line}\n")
 
     return buffer
@@ -60,30 +76,55 @@ def process_file(
     is passed back into the reformatted source code as-is. Leading whitespace in the line is not
     considered.
 
-    For example:
-        * `%  This is indented`
-        * `%    This is indented`
-        * `% This is not indented`
-        * `    % This is not indented`
-
     If `alternate_capital_handling` is `True`, if the line buffer has contents then a line beginning
     with a capital letter is treated as the start of a new comment block.
 
-    For example:
-        % This is a comment line
-        % This is a second comment line that will not be reflowed into the previous line
+    If `reflow_block_comments` is `True`, the contents of a block comment (delimited by `%{` and
+    `%}`) are reflowed. Per MATLAB's spec, the delimiters must be the only thing on their respective
+    lines.
+
+    View the README for code samples.
     """
     src = file.read_text().splitlines()
     with file.open("w") as f:
         buffer: deque = deque()
         indent_level = 0  # Number of leading spaces
+        in_comment_block = False
         for line in src:
             lstripped_line = line.lstrip()
+
+            # Check for the close of a block comment
+            if reflow_block_comments and lstripped_line.startswith("%}"):
+                # If we're exiting the block comment, reflow the contents & then write closing tag
+                # If we're here then the indent level will already be set by the logic further down
+                in_comment_block = False
+                buffer = _write_line(f, line, buffer, line_length, indent_level, is_block=True)
+                continue
+
+            # If we're inside a comment block, lines will likely not begin with a %
+            if reflow_block_comments and in_comment_block:
+                if buffer:
+                    # If this isn't the first line in the text block we need to add a leading space
+                    # to the line, otherwise it gets run into the last word from the previous line
+                    buffer.append(f" {lstripped_line}")
+                else:
+                    buffer.append(lstripped_line)
+
+                continue
+
             if lstripped_line.startswith("%"):
                 # Comment line
                 if not buffer:
                     # New buffer, set the indentation level for the incoming block
                     indent_level = _n_leading_spaces(line)
+
+                # Check for the opening of a block comment
+                if reflow_block_comments and lstripped_line.startswith("%{"):
+                    # If we're entering a block comment, dump out any existing buffer & write the
+                    # opening tag straight out
+                    in_comment_block = True
+                    buffer = _write_line(f, line, buffer, line_length, indent_level)
+                    continue
 
                 # Count the inner level of indentation of the comment itself to use for both the
                 # empty comment line check and the ignore indent check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pre-commit-matlab"
-version = "1.1.0"
+version = "1.2.0"
 description = "A Collection of pre-commit hooks for MATLAB"
 authors = ["sco1 <sco1.git@gmail.com>"]
 

--- a/tests/test_alternate_capital.py
+++ b/tests/test_alternate_capital.py
@@ -84,13 +84,21 @@ def test_alternate_capital_handling(  # noqa: D103
     # Check 100 width
     sample_file.write_text(in_src)
     matlab_reflow_comments.process_file(
-        sample_file, 100, ignore_indented=True, alternate_capital_handling=True
+        sample_file,
+        100,
+        ignore_indented=True,
+        alternate_capital_handling=True,
+        reflow_block_comments=True,
     )
     assert sample_file.read_text() == truth_100_width
 
     # Check 50 width
     sample_file.write_text(in_src)
     matlab_reflow_comments.process_file(
-        sample_file, 50, ignore_indented=True, alternate_capital_handling=True
+        sample_file,
+        50,
+        ignore_indented=True,
+        alternate_capital_handling=True,
+        reflow_block_comments=True,
     )
     assert sample_file.read_text() == truth_50_width

--- a/tests/test_block_comments.py
+++ b/tests/test_block_comments.py
@@ -72,6 +72,48 @@ BLOCK_COMMENT_TEST_CASES = [
         ),
     ),
     (
+        True,
+        dedent(
+            """\
+            function asdf = foo()
+                % Hello this is an inline comment
+                %{
+                This is a really long and descriptive block comment that has some
+                information about things and stuff and is indented and also spans
+                multiple lines
+                %}
+                asdf = 1;
+            end
+            """
+        ),
+        dedent(
+            """\
+            function asdf = foo()
+                % Hello this is an inline comment
+                %{
+                This is a really long and descriptive block comment that has some information about things and
+                stuff and is indented and also spans multiple lines
+                %}
+                asdf = 1;
+            end
+            """
+        ),
+        dedent(
+            """\
+            function asdf = foo()
+                % Hello this is an inline comment
+                %{
+                This is a really long and descriptive block
+                comment that has some information about things
+                and stuff and is indented and also spans
+                multiple lines
+                %}
+                asdf = 1;
+            end
+            """
+        ),
+    ),
+    (
         False,
         dedent(
             """\

--- a/tests/test_block_comments.py
+++ b/tests/test_block_comments.py
@@ -1,0 +1,148 @@
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from pre_commit_matlab import matlab_reflow_comments
+
+BLOCK_COMMENT_TEST_CASES = [
+    (
+        True,
+        dedent(
+            """\
+            %{
+            This is a really long and descriptive block comment that has some
+            information about things and stuff and also spans multiple lines
+            %}
+            """
+        ),
+        dedent(
+            """\
+            %{
+            This is a really long and descriptive block comment that has some information about things and stuff
+            and also spans multiple lines
+            %}
+            """
+        ),
+        dedent(
+            """\
+            %{
+            This is a really long and descriptive block
+            comment that has some information about things and
+            stuff and also spans multiple lines
+            %}
+            """
+        ),
+    ),
+    (
+        True,
+        dedent(
+            """\
+            %{
+            This is a really long and descriptive block comment that has some
+            information about things and stuff and also spans multiple lines
+            %}
+            function asdf = foo()
+                asdf = 1;
+            end
+            """
+        ),
+        dedent(
+            """\
+            %{
+            This is a really long and descriptive block comment that has some information about things and stuff
+            and also spans multiple lines
+            %}
+            function asdf = foo()
+                asdf = 1;
+            end
+            """
+        ),
+        dedent(
+            """\
+            %{
+            This is a really long and descriptive block
+            comment that has some information about things and
+            stuff and also spans multiple lines
+            %}
+            function asdf = foo()
+                asdf = 1;
+            end
+            """
+        ),
+    ),
+    (
+        False,
+        dedent(
+            """\
+            %{
+            a = zeros(10, 1);
+            for ii = 1:10
+                a[ii] = ii;
+            end
+            %}
+            """
+        ),
+        dedent(
+            """\
+            %{
+            a = zeros(10, 1);
+            for ii = 1:10
+                a[ii] = ii;
+            end
+            %}
+            """
+        ),
+        dedent(
+            """\
+            %{
+            a = zeros(10, 1);
+            for ii = 1:10
+                a[ii] = ii;
+            end
+            %}
+            """
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    (
+        "should_reflow",
+        "in_src",
+        "truth_100_width",
+        "truth_50_width",
+    ),
+    BLOCK_COMMENT_TEST_CASES,
+)
+def test_block_comment_reflow(  # noqa: D103
+    tmp_path: Path,
+    should_reflow: bool,
+    in_src: str,
+    truth_100_width: str,
+    truth_50_width: str,
+) -> None:
+    sample_file = tmp_path / "sample_src.m"
+
+    # Check 100 width
+    sample_file.write_text(in_src)
+    matlab_reflow_comments.process_file(
+        sample_file,
+        100,
+        ignore_indented=True,
+        alternate_capital_handling=False,
+        reflow_block_comments=should_reflow,
+    )
+    assert sample_file.read_text() == truth_100_width
+
+    # Check 50 width
+    sample_file.write_text(in_src)
+    matlab_reflow_comments.process_file(
+        sample_file,
+        50,
+        ignore_indented=True,
+        alternate_capital_handling=False,
+        reflow_block_comments=should_reflow,
+    )
+    assert sample_file.read_text() == truth_50_width

--- a/tests/test_reflow.py
+++ b/tests/test_reflow.py
@@ -259,13 +259,21 @@ def test_comment_reflow(  # noqa: D103
     # Check 100 width
     sample_file.write_text(in_src)
     matlab_reflow_comments.process_file(
-        sample_file, 100, ignore_indented=True, alternate_capital_handling=False
+        sample_file,
+        100,
+        ignore_indented=True,
+        alternate_capital_handling=False,
+        reflow_block_comments=True,
     )
     assert sample_file.read_text() == truth_100_width
 
     # Check 50 width
     sample_file.write_text(in_src)
     matlab_reflow_comments.process_file(
-        sample_file, 50, ignore_indented=True, alternate_capital_handling=False
+        sample_file,
+        50,
+        ignore_indented=True,
+        alternate_capital_handling=False,
+        reflow_block_comments=True,
     )
     assert sample_file.read_text() == truth_50_width


### PR DESCRIPTION
Adds handling for MATLAB's block comments

e.g. 

```matlab
%{
This is a really long and descriptive block comment that has some
information about things and stuff and also spans multiple lines
%}
function asdf = foo()
    asdf = 1;
end
```

Would reflow into:

```matlab
%{
This is a really long and descriptive block comment that has some information about things and stuff
and also spans multiple lines
%}
function asdf = foo()
    asdf = 1;
end
```

Though enabled by default, this behavior can be disabled using the `--reflow-block-comments` arg so things like the following aren't reflowed:

```matlab
%{
a = zeros(10, 1);
for ii = 1:10
    a[ii] = ii;
end
%}
```

While this is functional, I'd like to leave it as a draft until I can take a look at the overall flow & see if there's any refactoring that can be done, both as a general cleanup & also to see if the `--ignore-indented` behavior can also be applied to code blocks.

Closes #9